### PR TITLE
Auto compilation for releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,9 @@ jobs:
     - name: Build MrBig
       shell: bash
       run: |
+        pwd
+        ls "${{ github.workspace }}/../"
+        ls "${{ github.workspace }}"
         cd "${{ github.workspace }}"
         make
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,27 +47,23 @@ jobs:
     - name: Add tools to PATH
       shell: bash
       run: |
-        echo "C:/cygwin/bin" >> $GITHUB_PATH
-        echo "C:/msys64/mingw64/bin" >> $GITHUB_PATH
-        echo "C:/msys64/mingw32/bin" >> $GITHUB_PATH
-        echo "C:/msys64/usr/bin" >> $GITHUB_PATH
+        echo "D:/cygwin/bin" >> $GITHUB_PATH
+        echo "D:/msys64/mingw64/bin" >> $GITHUB_PATH
+        echo "D:/msys64/mingw32/bin" >> $GITHUB_PATH
+        echo "D:/msys64/usr/bin" >> $GITHUB_PATH
         
-    - name: Verify tool installation
-      shell: bash
+        
+        
+        
+    - name: Build MrBig (MSYS2 alternative)
+      shell: msys2 {0}
       run: |
-        echo "Checking tool availability..."
-        which make || echo "make not found"
-        which sh || echo "sh not found"
-        which zip || echo "zip not found"
-        which gcc || echo "gcc not found"
-        echo "Current PATH:"
         echo $PATH
-        
-    - name: Build MrBig
-      shell: bash
-      run: |
+        echo "Trying build in MSYS2 environment..."
+        pwd
+        ls -la
         make
-        
+
     - name: Create release archive
       if: startsWith(github.ref, 'refs/tags/')
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,120 @@
+name: Build and Release MrBig
+
+on:
+#   push:
+#     branches: [ main, master ]
+#     tags: [ 'v*' ]
+#   pull_request:
+    # branches: [ main, master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Setup Cygwin
+      uses: cygwin/cygwin-install-action@master
+      with:
+        packages: make zip gcc-core gcc-g++ binutils
+        
+    - name: Setup MinGW-w64
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        update: true
+        install: >-
+          mingw-w64-x86_64-gcc
+          mingw-w64-x86_64-make
+          mingw-w64-i686-gcc
+          mingw-w64-i686-make
+          make
+          
+    - name: Add tools to PATH
+      shell: bash
+      run: |
+        echo "C:/cygwin/bin" >> $GITHUB_PATH
+        echo "C:/msys64/mingw64/bin" >> $GITHUB_PATH
+        echo "C:/msys64/mingw32/bin" >> $GITHUB_PATH
+        echo "C:/msys64/usr/bin" >> $GITHUB_PATH
+        
+    - name: Verify tool installation
+      shell: bash
+      run: |
+        echo "Checking tool availability..."
+        which make || echo "make not found"
+        which sh || echo "sh not found"
+        which zip || echo "zip not found"
+        which gcc || echo "gcc not found"
+        echo "Current PATH:"
+        echo $PATH
+        
+    - name: Build MrBig
+      shell: bash
+      run: |
+        cd "${{ github.workspace }}"
+        make
+        
+    - name: Create release archive
+      if: startsWith(github.ref, 'refs/tags/')
+      shell: bash
+      run: |
+        cd "${{ github.workspace }}"
+        mkdir -p release
+        # Copy built binaries to release directory
+        if [ -f "mrbig.exe" ]; then
+          cp mrbig.exe release/
+        fi
+        if [ -d "X64" ] && [ -f "X64/mrbig.exe" ]; then
+          cp X64/mrbig.exe release/mrbig-x64.exe
+        fi
+        if [ -d "X86" ] && [ -f "X86/mrbig.exe" ]; then
+          cp X86/mrbig.exe release/mrbig-x86.exe
+        fi
+        # Create archive
+        cd release
+        zip -r ../mrbig-release.zip .
+        
+    # - name: Upload build artifacts
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: mrbig-binaries
+    #     path: |
+    #       mrbig.exe
+    #       X64/mrbig.exe
+    #       X86/mrbig.exe
+    #     if-no-files-found: warn
+        
+    # - name: Create GitHub Release
+    #   if: startsWith(github.ref, 'refs/tags/')
+    #   id: create_release
+    #   uses: actions/create-release@v1
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   with:
+    #     tag_name: ${{ github.ref_name }}
+    #     release_name: MrBig ${{ github.ref_name }}
+    #     body: |
+    #       Release of MrBig ${{ github.ref_name }}
+          
+    #       Built with:
+    #       - Cygwin (sh, make, zip)
+    #       - MinGW-w64 (64-bit and 32-bit toolchains)
+          
+    #       This release includes both 32-bit and 64-bit Windows binaries.
+    #     draft: false
+    #     prerelease: false
+        
+    # - name: Upload Release Asset
+    #   if: startsWith(github.ref, 'refs/tags/')
+    #   uses: actions/upload-release-asset@v1
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   with:
+    #     upload_url: ${{ steps.create_release.outputs.upload_url }}
+    #     asset_path: ./mrbig-release.zip
+    #     asset_name: mrbig-${{ github.ref_name }}.zip
+    #     asset_content_type: application/zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,23 +55,19 @@ jobs:
 
     - name: Create release archive
       if: startsWith(github.ref, 'refs/tags/')
-      shell: bash
+      shell: msys2 {0}
       run: |
-        cd "${{ github.workspace }}"
         mkdir -p release
         # Copy built binaries to release directory
         if [ -f "mrbig.exe" ]; then
           cp mrbig.exe release/
         fi
-        if [ -d "X64" ] && [ -f "X64/mrbig.exe" ]; then
-          cp X64/mrbig.exe release/mrbig-x64.exe
+        if [ -d "X64" ] && [ -f "X64/mrbig64.exe" ]; then
+          cp X64/mrbig64.exe release/mrbig64.exe
         fi
         if [ -d "X86" ] && [ -f "X86/mrbig.exe" ]; then
-          cp X86/mrbig.exe release/mrbig-x86.exe
+          cp X86/mrbig.exe release/mrbig.exe
         fi
-        # Create archive
-        cd release
-        zip -r ../mrbig-release.zip .
         
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Build MrBig
       shell: bash
       run: |
-        pwd
+        ls
         ls "${{ github.workspace }}/../"
         ls "${{ github.workspace }}"
         cd "${{ github.workspace }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,7 @@ jobs:
         fi
         
     - name: Upload build artifacts
+      if: github.event_name == 'release'
       uses: actions/upload-artifact@v4
       with:
         name: mrbig-binaries
@@ -77,4 +78,14 @@ jobs:
           X64/mrbig64.exe
           X86/mrbig.exe
         if-no-files-found: warn
-        
+
+    - name: Upload Release Assets
+      if: github.event_name == 'release'
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          X64/mrbig64.exe
+          X86/mrbig.exe
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,6 @@ jobs:
     - name: Build MrBig
       shell: bash
       run: |
-        cd "${{ github.workspace }}"
         make
         
     - name: Create release archive

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,10 +58,17 @@ jobs:
     - name: Build MrBig (MSYS2 alternative)
       shell: msys2 {0}
       run: |
-        echo $PATH
-        echo "Trying build in MSYS2 environment..."
+        export PATH="/mingw64/bin:/mingw32/bin:/usr/bin:$PATH"
+        echo "Updated PATH: $PATH"
+        echo "Checking available compilers:"
+        which gcc || echo "gcc not found"
+        which x86_64-w64-mingw32-gcc || echo "x86_64-w64-mingw32-gcc not found"
+        which i686-w64-mingw32-gcc || echo "i686-w64-mingw32-gcc not found"
+        echo "Current working directory:"
         pwd
+        echo "Contents:"
         ls -la
+        echo "Running make..."
         make
 
     - name: Create release archive

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,8 @@
 name: Build and Release MrBig
 
 on:
-#   push:
-#     branches: [ main, master ]
-#     tags: [ 'v*' ]
-#   pull_request:
-    # branches: [ main, master ]
+  release:
+    types: [published]
   workflow_dispatch:
 
 jobs:
@@ -44,30 +41,15 @@ jobs:
         echo Looking for Makefile:
         dir "${{ github.workspace }}\Makefile"
         
-    - name: Add tools to PATH
-      shell: bash
-      run: |
-        echo "D:/cygwin/bin" >> $GITHUB_PATH
-        echo "D:/msys64/mingw64/bin" >> $GITHUB_PATH
-        echo "D:/msys64/mingw32/bin" >> $GITHUB_PATH
-        echo "D:/msys64/usr/bin" >> $GITHUB_PATH
         
-        
-        
-        
-    - name: Build MrBig (MSYS2 alternative)
+    - name: Build MrBig
       shell: msys2 {0}
       run: |
         export PATH="/mingw64/bin:/mingw32/bin:/usr/bin:$PATH"
-        echo "Updated PATH: $PATH"
         echo "Checking available compilers:"
         which gcc || echo "gcc not found"
         which x86_64-w64-mingw32-gcc || echo "x86_64-w64-mingw32-gcc not found"
         which i686-w64-mingw32-gcc || echo "i686-w64-mingw32-gcc not found"
-        echo "Current working directory:"
-        pwd
-        echo "Contents:"
-        ls -la
         echo "Running make..."
         make
 
@@ -91,43 +73,12 @@ jobs:
         cd release
         zip -r ../mrbig-release.zip .
         
-    # - name: Upload build artifacts
-    #   uses: actions/upload-artifact@v4
-    #   with:
-    #     name: mrbig-binaries
-    #     path: |
-    #       mrbig.exe
-    #       X64/mrbig.exe
-    #       X86/mrbig.exe
-    #     if-no-files-found: warn
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: mrbig-binaries
+        path: |
+          X64/mrbig64.exe
+          X86/mrbig.exe
+        if-no-files-found: warn
         
-    # - name: Create GitHub Release
-    #   if: startsWith(github.ref, 'refs/tags/')
-    #   id: create_release
-    #   uses: actions/create-release@v1
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   with:
-    #     tag_name: ${{ github.ref_name }}
-    #     release_name: MrBig ${{ github.ref_name }}
-    #     body: |
-    #       Release of MrBig ${{ github.ref_name }}
-          
-    #       Built with:
-    #       - Cygwin (sh, make, zip)
-    #       - MinGW-w64 (64-bit and 32-bit toolchains)
-          
-    #       This release includes both 32-bit and 64-bit Windows binaries.
-    #     draft: false
-    #     prerelease: false
-        
-    # - name: Upload Release Asset
-    #   if: startsWith(github.ref, 'refs/tags/')
-    #   uses: actions/upload-release-asset@v1
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   with:
-    #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-    #     asset_path: ./mrbig-release.zip
-    #     asset_name: mrbig-${{ github.ref_name }}.zip
-    #     asset_content_type: application/zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,17 @@ jobs:
           mingw-w64-i686-make
           make
           
+    - name: Debug workspace contents (Windows)
+      shell: cmd
+      run: |
+        echo Current working directory:
+        cd
+        echo Workspace directory: ${{ github.workspace }}
+        echo Contents of workspace:
+        dir "${{ github.workspace }}"
+        echo Looking for Makefile:
+        dir "${{ github.workspace }}\Makefile"
+        
     - name: Add tools to PATH
       shell: bash
       run: |
@@ -55,9 +66,6 @@ jobs:
     - name: Build MrBig
       shell: bash
       run: |
-        ls
-        ls "${{ github.workspace }}/../"
-        ls "${{ github.workspace }}"
         cd "${{ github.workspace }}"
         make
         


### PR DESCRIPTION
Automatically compile binaries and attach them to created releases, all using github workflows with no changes to makefile.

I had to commit each change to test it. Probably do squash commit if merge.