### PR TITLE
Auto file properties & simplified workflow compilation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,49 +13,37 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       
-    - name: Setup Cygwin
+    - name: Setup Cygwin (with MinGW toolchains)
       uses: cygwin/cygwin-install-action@master
       with:
-        packages: make zip gcc-core gcc-g++ binutils
-        
-    - name: Setup MinGW-w64
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: MINGW64
-        update: true
-        install: >-
-          mingw-w64-x86_64-gcc
-          mingw-w64-x86_64-make
-          mingw-w64-i686-gcc
-          mingw-w64-i686-make
-          make
-          
-    - name: Debug workspace contents (Windows)
-      shell: cmd
-      run: |
-        echo Current working directory:
-        cd
-        echo Workspace directory: ${{ github.workspace }}
-        echo Contents of workspace:
-        dir "${{ github.workspace }}"
-        echo Looking for Makefile:
-        dir "${{ github.workspace }}\Makefile"
-        
-        
+        # include mingw packages so prefixed toolchains are available under /usr/bin
+        platform: x86_64
+        packages: |
+          make zip gcc-core gcc-g++ binutils 
+          mingw64-x86_64-gcc-core mingw64-x86_64-binutils mingw64-x86_64-gcc-g++ 
+          mingw64-i686-gcc-core mingw64-i686-binutils mingw64-i686-gcc-g++
+      
     - name: Build MrBig
-      shell: msys2 {0}
+      shell: C:\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
       run: |
-        export PATH="/mingw64/bin:/mingw32/bin:/usr/bin:$PATH"
-        echo "Checking available compilers:"
-        which gcc || echo "gcc not found"
-        which x86_64-w64-mingw32-gcc || echo "x86_64-w64-mingw32-gcc not found"
-        which i686-w64-mingw32-gcc || echo "i686-w64-mingw32-gcc not found"
-        echo "Running make..."
-        make
+        cd "$GITHUB_WORKSPACE"
+        echo "Building MrBig"
+        make all
+        
+    - name: Verify built binaries
+      shell: C:\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
+      run: |
+        cd "$GITHUB_WORKSPACE"
+        echo "Verifying built binaries"
+        file X86/mrbig.exe || echo "X86/mrbig.exe not found"
+        file X64/mrbig64.exe || echo "X64/mrbig64.exe not found"
+        echo "Listing build directories:"
+        ls -l X86 
+        ls -l X64
 
     - name: Create release archive
       if: startsWith(github.ref, 'refs/tags/')
-      shell: msys2 {0}
+      shell: C:\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
       run: |
         mkdir -p release
         # Copy built binaries to release directory

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Object files
 *.o
 
+# Resource files (compiled)
+*.rc
+*.res
+
 # Executables
 *.exe
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,17 @@
 
 PACKAGE=MrBig
-VERSION=0.26.3
+VERSION=0.26.3.0
+
+COMPANY=Axians AB
+COPYRIGHT=Correct Copyright later
+DESCRIPTION=Correct Description later
+PRODUCT=MrBig 
+INTERNAL=MrBig
+COMMENTS=MrBig System Information and Monitoring Tool
+
+VER_RC=winver.rc
+VER_RES=winver.res
+
 #CFLAGS=-Wall -O -g -DDEBUG
 CFLAGS=-Wall -Werror -O2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ggdb -DPACKAGE=\"$(PACKAGE)\" -DVERSION=\"$(VERSION)\"
 DOCS=INSTALL EVENTS ChangeLog DEVELOPMENT TODO EXT LARRD logs.cmd testfile.txt
@@ -28,9 +39,51 @@ EXEFILES=X86/mrbig.exe X64/mrbig64.exe
 ARCHIVE=ulric@tiffany.365-24.se:/usr/local/apache/vhosts/extranet.365-24.se/MrBig/Archive
 BETAVERSION=`date +%y%m%d%H%M`
 
+BUILD_DATE=$(shell date +%y%m%d%H%M)
+GIT_HASH=$(shell git rev-parse --short HEAD)
+GIT_DIRTY=$(shell git diff --quiet || echo -dirty)
+
+FILEVER_COMMA = $(shell echo $(VERSION) | awk -F. '{printf "%s,%s,%s,%s", $$1,$$2,$$3,$$4}')
+
+# -----------------------------
+# Version string logic
+# -----------------------------
+ifeq ($(DEV),1)
+	# Dev/Beta: 1.2.3.4-betaYYMMDDHHMM+HASH-dirty
+	FILEVER_STR := $(VERSION)-dev$(BUILD_DATE)+$(GIT_HASH)$(GIT_DIRTY)
+else
+	# Release: 1.2.3.4+HASH
+	FILEVER_STR := $(VERSION)+$(GIT_HASH)
+endif
+
+
+ifneq ($(strip $(ARCH)),)
+ORIG_EXE := mrbig$(ARCH).exe
+else
+ORIG_EXE := mrbig.exe
+endif
+
 all:
 	$(MAKE) -C X86 mrbig.exe
 	$(MAKE) -C X64 mrbig64.exe
+
+$(VER_RC): version.rc.template
+	sed -e 's/@COMPANY@/$(COMPANY)/g' \
+	    -e 's/@PRODUCT@/$(PACKAGE)/g' \
+	    -e 's/@PACKAGE@/$(PACKAGE)/g' \
+		-e 's/@FILEVER@/$(FILEVER_STR)/g' \
+		-e 's/@FILEVER_COMMA@/$(FILEVER_COMMA)/g' \
+		-e 's/@COPYRIGHT@/$(COPYRIGHT)/g' \
+		-e 's/@DESCRIPTION@/$(DESCRIPTION)/g' \
+		-e 's/@ORIGINALFILENAME@/$(ORIG_EXE)/g' \
+		-e 's/@INTERNAL@/$(INTERNAL)/g' \
+		-e 's/@COMMENTS@/$(COMMENTS)/g' \
+	    $< > $@
+# Build the version resource. WINDRES must be set by the arch specific Makefile
+# (X86/Makefile or X64/Makefile) so that the correct prefixed windres tool is used.
+$(VER_RES): $(VER_RC)
+	$(WINDRES) -O coff $(VER_RC) -o $(VER_RES)
+
 
 mrwmi:
 	$(MAKE) -C X86 mrwmi.exe
@@ -39,11 +92,13 @@ mrwmi:
 mrwmi.exe: $(OBJS) wmi.o disphelper.o
 	$(CC) -o mrwmi.exe $(OBJS) wmi.o disphelper.o -lws2_32 -lpsapi -lole32 -loleaut32 -luuid -lcrypt32 -lwevtapi -lpdh -lwtsapi32
 
-mrbig.exe: $(OBJS) clientlog.o
-	$(CC) -o mrbig.exe $(OBJS) $(CLIENTLOGOBJS_32) -lws2_32 -lpsapi -lole32 -loleaut32 -luuid -liphlpapi -lcrypt32 -lwevtapi -lpdh -lwtsapi32
+mrbig.exe: $(OBJS) clientlog.o $(VER_RES)
+	@echo "Building mrbig.exe"
+	$(CC) -o mrbig.exe $(OBJS) $(CLIENTLOGOBJS_32)  $(VER_RES) -lws2_32 -lpsapi -lole32 -loleaut32 -luuid -liphlpapi -lcrypt32 -lwevtapi -lpdh -lwtsapi32
 
-mrbig64.exe: $(OBJS) clientlog.o
-	$(CC) -o mrbig64.exe $(OBJS) $(CLIENTLOGOBJS_64) -lws2_32 -lpsapi -lole32 -loleaut32 -luuid -liphlpapi -lcrypt32 -lwevtapi -lpdh -lwtsapi32
+mrbig64.exe: $(OBJS) clientlog.o $(VER_RES)
+	@echo "Building mrbig64.exe"
+	$(CC) -o mrbig64.exe $(OBJS) $(CLIENTLOGOBJS_64)  $(VER_RES) -lws2_32 -lpsapi -lole32 -loleaut32 -luuid -liphlpapi -lcrypt32 -lwevtapi -lpdh -lwtsapi32
 
 mrbignt.exe: $(NTOBJS)
 	$(CC) -o mrbignt.exe $(NTOBJS) -lws2_32 -lpsapi
@@ -102,12 +157,14 @@ clean:
 	make -C clientlog clean
 
 .clean:
-	rm -f *.o *.exe *~ *.stackdump
+	rm -f *.o *.exe *~ *.stackdump *.res *.rc
 
 #zip: $(ZIPFILES)
 #	strip mrbig.exe
 #	zip $(PACKAGE)-$(VERSION).zip $(ZIPFILES)
 #
+gitversion:
+	$(MAKE) GITCOMMIT=1 all
 
 zip: $(ZIPFILES) all
 	zip $(PACKAGE)-$(VERSION).zip $(ZIPFILES) $(EXEFILES)
@@ -130,4 +187,7 @@ beta:
 	rm -f X86/mrbig.exe
 	$(MAKE) all
 	scp X86/mrbig.exe $(ARCHIVE)/Beta/mrbig-$(BETAVERSION)-beta.exe
+
+dev:
+	$(MAKE) DEV=1 all
 

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@ PACKAGE=MrBig
 VERSION=0.26.3.0
 
 COMPANY=Axians AB
-COPYRIGHT=Correct Copyright later
-DESCRIPTION=Correct Description later
+COPYRIGHT=Axians AB - GNU GPLv3
+DESCRIPTION=MrBig client for Xymon
 PRODUCT=MrBig 
 INTERNAL=MrBig
-COMMENTS=MrBig System Information and Monitoring Tool
+COMMENTS=MrBig client for Xymon
 
 VER_RC=winver.rc
 VER_RES=winver.res

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ VERSION=0.26.3.0
 COMPANY=Axians AB
 COPYRIGHT=Axians AB - GNU GPLv3
 DESCRIPTION=MrBig client for Xymon
-PRODUCT=MrBig 
-INTERNAL=MrBig
+PRODUCT=MrBig client for Xymon
+INTERNAL=MrBig client for Xymon
 COMMENTS=MrBig client for Xymon
 
 VER_RC=winver.rc
@@ -49,11 +49,11 @@ FILEVER_COMMA = $(shell echo $(VERSION) | awk -F. '{printf "%s,%s,%s,%s", $$1,$$
 # Version string logic
 # -----------------------------
 ifeq ($(DEV),1)
-	# Dev/Beta: 1.2.3.4-betaYYMMDDHHMM+HASH-dirty
+# Dev/Beta: 1.2.3.4-betaYYMMDDHHMM+HASH[-dirty]
 	FILEVER_STR := $(VERSION)-dev$(BUILD_DATE)+$(GIT_HASH)$(GIT_DIRTY)
 else
-	# Release: 1.2.3.4+HASH
-	FILEVER_STR := $(VERSION)+$(GIT_HASH)
+# Release: 1.2.3.4
+	FILEVER_STR := $(VERSION)
 endif
 
 
@@ -69,7 +69,7 @@ all:
 
 $(VER_RC): version.rc.template
 	sed -e 's/@COMPANY@/$(COMPANY)/g' \
-	    -e 's/@PRODUCT@/$(PACKAGE)/g' \
+	    -e 's/@PRODUCT@/$(PRODUCT)/g' \
 	    -e 's/@PACKAGE@/$(PACKAGE)/g' \
 		-e 's/@FILEVER@/$(FILEVER_STR)/g' \
 		-e 's/@FILEVER_COMMA@/$(FILEVER_COMMA)/g' \
@@ -163,9 +163,6 @@ clean:
 #	strip mrbig.exe
 #	zip $(PACKAGE)-$(VERSION).zip $(ZIPFILES)
 #
-gitversion:
-	$(MAKE) GITCOMMIT=1 all
-
 zip: $(ZIPFILES) all
 	zip $(PACKAGE)-$(VERSION).zip $(ZIPFILES) $(EXEFILES)
 

--- a/X64/Makefile
+++ b/X64/Makefile
@@ -1,5 +1,7 @@
 
 VPATH=..
 CC=x86_64-w64-mingw32-gcc -m64
+WINDRES=x86_64-w64-mingw32-windres
+ARCH=64
 include ../Makefile
 

--- a/X86/Makefile
+++ b/X86/Makefile
@@ -1,5 +1,6 @@
 
 VPATH=..
 CC=i686-w64-mingw32-gcc -m32
+WINDRES=i686-w64-mingw32-windres
 include ../Makefile
 

--- a/version.rc.template
+++ b/version.rc.template
@@ -1,0 +1,31 @@
+#include <windows.h>
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION     @FILEVER_COMMA@
+PRODUCTVERSION  @FILEVER_COMMA@
+FILEFLAGSMASK   0x3fL
+FILEFLAGS       0x0L
+FILEOS          VOS__WINDOWS32
+FILETYPE        VFT_APP
+FILESUBTYPE     VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName",      "@COMPANY@"
+            VALUE "FileDescription",  "@DESCRIPTION@"
+            VALUE "FileVersion",      "@FILEVER@"
+            VALUE "InternalName",     "@INTERNAL@"
+            VALUE "LegalCopyright",   "@COPYRIGHT@"
+            VALUE "OriginalFilename", "@ORIGINALFILENAME@"
+            VALUE "ProductName",      "@PRODUCT@"
+            VALUE "ProductVersion",   "@FILEVER@"
+            VALUE "Comments",          "@COMMENTS@"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END


### PR DESCRIPTION
Switched fully to cygwin instead of msys2 in release compilation.
Fileproperties are automatically compiled into the file with the correct version number and description.
Shown here:
<img width="396" height="324" alt="image" src="https://github.com/user-attachments/assets/153cf3e2-b05b-4f26-a47f-e203bee73daf" />

Added a new `dev` entry in the makefile that set the product version to `1.2.3.4-devYYMMDDHHMM+commit hash[-dirty]` which makes it easier to know when the file was compiled and which commit. Could easily create one with just the commit hash to use with, for example, PRs.