### PR TITLE
Change msgs to opt in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@
 *.tar.bz2
 
 .vscode
+
+compile_commands.json
+
+# logfile
+mrlog.log
+.cache/

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+260203	Changed Msgs to default to disabled with opt-in
+				seemed to cause crashes when loading in registry.
+				enable with option enable_msgs
+
 251517  Added Clientlog module, which writes a big log of rows,
         containg information about the Windows machine. Most info
 		modules are recreations of Linux command line utilities.

--- a/msgs.c
+++ b/msgs.c
@@ -179,7 +179,7 @@ void msgs(void)
 	if (debug > 1) mrlog("msgs(%p, %d)", b, n);
 
 	if (!get_option("enable_msgs", 0)) {
-		mrsend(mrmachine, "msgs", "clear", "option enable_msgs not set\n");
+		mrsend(mrmachine, "msgs", "clear", "msgs disabled, enable with option enable_msgs\n");
 		return;
 	}
 

--- a/msgs.c
+++ b/msgs.c
@@ -178,8 +178,8 @@ void msgs(void)
 
 	if (debug > 1) mrlog("msgs(%p, %d)", b, n);
 
-	if (get_option("no_msgs", 0)) {
-		mrsend(mrmachine, "msgs", "clear", "option no_msgs\n");
+	if (!get_option("enable_msgs", 0)) {
+		mrsend(mrmachine, "msgs", "clear", "option enable_msgs not set\n");
 		return;
 	}
 


### PR DESCRIPTION
This pull request updates the logic for enabling or disabling message sending in the `msgs` function. Instead of checking for a "no_msgs" option to disable messages, the code now checks for an "enable_msgs" option to explicitly allow them. This makes the intent clearer and should prevent MrBig from crashing due to `msgs`

Configuration logic update:

* Changed the conditional in the `msgs` function in `msgs.c` to check for the `enable_msgs` option instead of `no_msgs`, and updated the corresponding message for clarity.