### PR TITLE
Bump GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install MinGW cross-compilers
       run: |
@@ -25,7 +25,7 @@ jobs:
       run: make all
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: mrbig-binaries
         path: |

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install MinGW cross-compilers
       run: |
@@ -26,7 +26,7 @@ jobs:
 
     - name: Upload build artifacts
       if: github.event_name == 'release'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: mrbig-binaries
         path: |


### PR DESCRIPTION
actions/checkout v4 -> v6
actions/upload-artifact v4 -> v7