### PR TITLE
Fix typo in SMT total log message in cpuinfo.c

### DIFF
--- a/clientlog/cpuinfo.c
+++ b/clientlog/cpuinfo.c
@@ -85,7 +85,7 @@ void clog_cpuinfo(clog_Arena scratch) {
     } else {
         clog_ArenaAppend(&scratch, "    SMT per core: N/A\n");
     }
-    clog_ArenaAppend(&scratch, " .      MT total: %d\n", total);
+    clog_ArenaAppend(&scratch, "       SMT total: %d\n", total);
 }
 
 #ifdef STANDALONE


### PR DESCRIPTION
fix typo
from
```
[cpuinfo]
     CPU Sockets: 1
Cores per socket: 2
     cores total: 2
    SMT per core: 1
 .      MT total: 2
```
to
```
[cpuinfo]
     CPU Sockets: 1
Cores per socket: 2
     cores total: 2
    SMT per core: 1
       SMT total: 2
```