### PR TITLE
Move last clientlog sections

### DIFF
--- a/clientlog/clientlog.c
+++ b/clientlog/clientlog.c
@@ -35,23 +35,29 @@ void clientlog(char *mrmachine, void (*mrsend)(char *machine, char *message), vo
 
     LOG_DEBUG("Clientlog start message");
     clog_ArenaAppend(&arena, "client %s.windows windows\n", mrmachine);
+    clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_date, arena);
     clog_ArenaAppend(&arena, "\n");
+    clog_ArenaAppend(&arena, "\n"); // one line space between sections
 
     RUN(clog_osversion, arena);
+    clog_ArenaAppend(&arena, "\n");
     clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_winuptime, arena);
     clog_ArenaAppend(&arena, "\n");
+    clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_bios, arena);
-    // No newline
+    clog_ArenaAppend(&arena, "\n"); // already has a newline at the end of bios info, so only one newline here
 
     RUN(clog_domain, arena);
     clog_ArenaAppend(&arena, "\n");
+    clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_who, 10, arena);
+    clog_ArenaAppend(&arena, "\n");
     clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_cpuinfo, arena);
@@ -59,8 +65,10 @@ void clientlog(char *mrmachine, void (*mrsend)(char *machine, char *message), vo
 
     RUN(clog_diskinfo, arena);
     clog_ArenaAppend(&arena, "\n");
+    clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_winmemory, arena);
+    clog_ArenaAppend(&arena, "\n");
     clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_ipconfig, arena);
@@ -71,36 +79,44 @@ void clientlog(char *mrmachine, void (*mrsend)(char *machine, char *message), vo
 
     RUN(clog_winports, arena);
     clog_ArenaAppend(&arena, "\n");
+    clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_tcp_connections, arena);
     clog_ArenaAppend(&arena, "\n");
+    clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_processes_EndAppendQuery, hProcesses, &arena);
-    // No newline
+    clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_runningservices, arena);
-    // No newline
+    clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_eventlog, 5, arena);
     clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_applications, arena);
     clog_ArenaAppend(&arena, "\n");
+    clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_kbs, arena);
+    clog_ArenaAppend(&arena, "\n");
     clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_certificates, arena);
     clog_ArenaAppend(&arena, "\n");
+    clog_ArenaAppend(&arena, "\n");
+
+    RUN(clog_registry, arena);
+    clog_ArenaAppend(&arena, "\n");
+    clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_reboots, 5, arena);
+    clog_ArenaAppend(&arena, "\n");
     clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_clientversion, arena);
     clog_ArenaAppend(&arena, "\n");
 
-    RUN(clog_registry, arena);
-    clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_clock, arena);
     // No newline

--- a/clientlog/clientlog.c
+++ b/clientlog/clientlog.c
@@ -116,6 +116,7 @@ void clientlog(char *mrmachine, void (*mrsend)(char *machine, char *message), vo
 
     RUN(clog_clientversion, arena);
     clog_ArenaAppend(&arena, "\n");
+    clog_ArenaAppend(&arena, "\n");
 
 
     RUN(clog_clock, arena);

--- a/clientlog/clientlog.c
+++ b/clientlog/clientlog.c
@@ -37,6 +37,10 @@ void clientlog(char *mrmachine, void (*mrsend)(char *machine, char *message), vo
     clog_ArenaAppend(&arena, "client %s.windows windows\n", mrmachine);
     clog_ArenaAppend(&arena, "\n");
 
+    // decided to add a new line between each section for better readability, so each section will have two newlines after it
+    // some clientlog tests already have a newline at the end of their output, so we only need to add one more newline after those sections
+    // but most don't, so we need to add two newlines after those sections
+
     RUN(clog_date, arena);
     clog_ArenaAppend(&arena, "\n");
     clog_ArenaAppend(&arena, "\n"); // one line space between sections

--- a/clientlog/eventlog.c
+++ b/clientlog/eventlog.c
@@ -1,3 +1,4 @@
+#include "arena.h"
 #include "clientlog.h"
 #include <time.h>
 #include <winevt.h>
@@ -161,6 +162,7 @@ void clog_eventlog(DWORD maxNumEvents, clog_Arena scratch) {
         } else {
             clog_ArenaAppend(&scratch, "\n(No warnings or errors found within the last %lfh.)", MAX_EVENT_AGE_MS / 3600000.0);
         }
+        clog_ArenaAppend(&scratch, "\n");
         clog_PopDefer(&scratch);
     }
 }

--- a/clientlog/processes.c
+++ b/clientlog/processes.c
@@ -365,7 +365,7 @@ void clog_processes_EndAppendQuery(processes_Handle h, clog_Arena *a)
         processes_AppendTable(endedQuery, endedQuery.NumRows, a);
     }
 
-    clog_ArenaAppend(a, "[topprocessescpu]");
+    clog_ArenaAppend(a, "\n[topprocessescpu]");
     if (startedQuery->ErrorCode != ERROR_SUCCESS || endedQuery.ErrorCode != ERROR_SUCCESS) {
         clog_ArenaAppend(a, "\n(Unable to query processes, error code %#010x)\n",
                          startedQuery->ErrorCode != ERROR_SUCCESS ? startedQuery->ErrorCode : endedQuery.ErrorCode);
@@ -374,7 +374,7 @@ void clog_processes_EndAppendQuery(processes_Handle h, clog_Arena *a)
         processes_AppendTable(endedQuery, NUM_TOPPROCESSES, a);
     }
 
-    clog_ArenaAppend(a, "[topprocessesmemory]");
+    clog_ArenaAppend(a, "\n[topprocessesmemory]");
     if (startedQuery->ErrorCode != ERROR_SUCCESS || endedQuery.ErrorCode != ERROR_SUCCESS) {
         clog_ArenaAppend(a, "\n(Unable to query processes, error code %#010x)\n",
                          startedQuery->ErrorCode != ERROR_SUCCESS ? startedQuery->ErrorCode : endedQuery.ErrorCode);

--- a/clientlog/winports.c
+++ b/clientlog/winports.c
@@ -273,7 +273,7 @@ void clog_winports(clog_Arena scratch) {
     else if (errored > 0)
         clog_ArenaAppend(&scratch, "\n(Unable to get some of the networking statistics)");
 
-    clog_ArenaAppend(&scratch, "\n[winports]");
+    clog_ArenaAppend(&scratch, "\n\n[winports]");
     clog_ArenaAppend(&scratch, "\n%-7s\t%-39s\t%-39s\t%-15s\t%7s", "Proto", "Local Address", "Foreign Address", "State", "PID");
     errored = 0;
     for (int i = 0; i < lengthof(portGroups); i++) {


### PR DESCRIPTION
From
```
[registry]
HKLM\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Domain:	alpha.arpa
[clock]
epoch: 1785157266
local: 2026-07-27 13:01:06
ISO: 2026-07-27T13:01:06+00:00
UTC: 2026-07-27 13:01:06
Time Synchronisation type: NT5DS
NTP server: time.windows.com,0x8
Leap Indicator: 0(no warning)
Stratum: 1 (primary reference - syncd by radio clock)
Precision: -23 (119.209ns per tick)
Root Delay: 0.0000000s
Root Dispersion: 10.0000000s
ReferenceId: 0x4C4F434C (source name:  "LOCL")
Last Successful Sync Time: 7/27/2026 12:56:34 PM
Source: Free-running System Clock
Poll Interval: 6 (64s)

```

To
```
[registry]
HKLM\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Domain:	alpha.arpa

[reboots]
Date                   	User                           	Reason                                         
2026-07-20 12:54:39    	NT AUTHORITY\SYSTEM            	No title for this reason could be found
2026-07-20 10:38:32    	NT AUTHORITY\SYSTEM            	No title for this reason could be found

[clientversion]
MrBig version 0.26.6-dev (move-last-clientlog-sections@f8053e8-dirty)

[clock]
epoch: 1785157091
local: 2026-07-27 12:58:11
ISO: 2026-07-27T12:58:11+00:00
UTC: 2026-07-27 12:58:11
Time Synchronisation type: NT5DS
NTP server: time.windows.com,0x8
Leap Indicator: 0(no warning)
Stratum: 1 (primary reference - syncd by radio clock)
Precision: -23 (119.209ns per tick)
Root Delay: 0.0000000s
Root Dispersion: 10.0000000s
ReferenceId: 0x4C4F434C (source name:  "LOCL")
Last Successful Sync Time: 7/27/2026 12:56:34 PM
Source: Free-running System Clock
Poll Interval: 6 (64s)

```

For all sections