### PR TITLE
Release tag version enhancment

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -22,7 +22,14 @@ jobs:
         sudo apt-get install -y make mingw-w64 binutils-mingw-w64 zip
 
     - name: Build MrBig
-      run: make all
+      run: |
+        TAG="${GITHUB_REF_NAME#v}"
+        if [ "${{ github.event_name }}" = "release" ] && [ -n "$TAG" ]; then
+          [ "${{ github.event.release.prerelease }}" = "true" ] && TAG="${TAG}-pre"
+          make all VERSION="$TAG"
+        else
+          make all
+        fi
 
     - name: Upload build artifacts
       if: github.event_name == 'release'

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -21,6 +21,17 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y make mingw-w64 binutils-mingw-w64 zip
 
+    - name: Verify tag matches Makefile version
+      if: github.event_name == 'release'
+      run: |
+        TAG="${GITHUB_REF_NAME#v}"
+        TAG_BASE="${TAG%%-*}"  # strip pre-release suffix (e.g. 1.0.0-rc -> 1.0.0)
+        MAKEFILE_VERSION=$(grep -m1 '^VERSION=' Makefile | cut -d= -f2)
+        if [ "$TAG_BASE" != "$MAKEFILE_VERSION" ]; then
+          echo "Tag version ($TAG) does not match Makefile version ($MAKEFILE_VERSION)"
+          exit 1
+        fi
+
     - name: Build MrBig
       run: |
         TAG="${GITHUB_REF_NAME#v}"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -25,7 +25,6 @@ jobs:
       run: |
         TAG="${GITHUB_REF_NAME#v}"
         if [ "${{ github.event_name }}" = "release" ] && [ -n "$TAG" ]; then
-          [ "${{ github.event.release.prerelease }}" = "true" ] && TAG="${TAG}-pre"
           make all VERSION="$TAG"
         else
           make all

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2026-08-03 Compilation now sets the fileversion based on release tag
+    Sets the version based on release tag. Example: tag v0.0.1 -> MrBig 0.0.1
+    Supports pre-releases, gets -pre appended to version.
+
 2026-07-21 Realese MrBig-0.26.6
 
 2026-07-21 Update Changelog formatting to be more readable and consistent.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 2026-08-03 Compilation now sets the fileversion based on release tag
     Sets the version based on release tag. Example: tag v0.0.1 -> MrBig 0.0.1
-    Supports pre-releases, gets -pre appended to version.
+    rc are made by naming the tag v0.0.1-rc and the fileversion will follow that.
 
 2026-08-03 Order kbs by install date
 

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ GIT_DIRTY=$(shell git diff --quiet || echo -dirty)
 BRANCH := $(shell echo $${GITHUB_HEAD_REF:-$${GITHUB_REF_NAME:-$$(git rev-parse --abbrev-ref HEAD)}})
 
 
-FILEVER_COMMA = $(shell echo $(VERSION) | awk -F. '{printf "%s,%s,%s,0", $$1,$$2,$$3}')
+FILEVER_COMMA = $(shell echo $(VERSION) | sed 's/-.*//' | awk -F. '{printf "%s,%s,%s,0", $$1,$$2,$$3}')
 
 # -----------------------------
 # Version string logic
@@ -69,6 +69,7 @@ endif
 all:
 	$(MAKE) -C X86 mrbig.exe
 	$(MAKE) -C X64 mrbig64.exe
+.PHONY: $(VER_RC) $(VER_RES)
 
 $(VER_RC): version.rc.template
 	sed -e 's/@COMPANY@/$(COMPANY)/g' \


### PR DESCRIPTION
Github now compiles in the fileversion based on the release tag so it always matches.
Always recompiles the versionrc files
support pre-releases by appending a -pre to the version

parse version with `sed`