### PR TITLE
Update GitHub Actions to latest majors

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Install MinGW cross-compilers
       run: |

--- a/.github/workflows/pr-enforce-changelog.yml
+++ b/.github/workflows/pr-enforce-changelog.yml
@@ -14,7 +14,7 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: dangoslen/changelog-enforcer@v3.7.0
         with:
           changelogPath: ChangeLog

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Install MinGW cross-compilers
       run: |
@@ -52,7 +52,7 @@ jobs:
 
     - name: Upload Release Assets
       if: github.event_name == 'release'
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3
       with:
         files: |
           X64/mrbig64.exe


### PR DESCRIPTION
## Summary
Update GitHub Actions references in workflow files to current major versions on the develop-based branch.

## What Changed
- Updated actions/checkout from v6 to v7 in:
  - .github/workflows/pr-build.yml
  - .github/workflows/pr-enforce-changelog.yml
  - .github/workflows/release-build.yml
- Updated softprops/action-gh-release from v1 to v3 in:
  - .github/workflows/release-build.yml

## Unchanged (already current)
- actions/upload-artifact remains on v7
- mshick/add-pr-comment remains on v3
- dangoslen/changelog-enforcer remains on v3.7.0

## Why
- Keep workflow dependencies aligned with latest maintained major versions.
- Reduce drift and keep CI/release automation current.

## Risk / Impact
- Low to medium: action major bumps can include runtime and behavior changes.
- No project source/build logic was modified; only workflow action references were changed.
