### PR TITLE
Clientlog spacing

### DIFF
--- a/clientlog/applications.c
+++ b/clientlog/applications.c
@@ -147,6 +147,8 @@ void clog_applications(clog_Arena scratch) {
     } else {
         clog_ArenaAppend(&scratch, "\n(No applications found)");
     }
+    clog_utils_TrimTrailingNewlines(&scratch, NULL);
+    clog_ArenaAppend(&scratch, "\n");
 }
 
 #ifdef STANDALONE

--- a/clientlog/bios.c
+++ b/clientlog/bios.c
@@ -37,12 +37,14 @@ void clog_bios(clog_Arena scratch) {
 
     clog_PopDeferAll(&scratch);
 #undef clog_APPEND_BIOS
+    clog_utils_TrimTrailingNewlines(&scratch, NULL);
+    clog_ArenaAppend(&scratch, "\n");
 }
 
 #ifdef STANDALONE
 int main(int argc, CHAR *argv[]) {
     clog_ArenaState *st = clog_ArenaMake(0x20000);
-    clog_reboots(5, st->Memory);
+    clog_bios(5, st->Memory);
     printf("%s", st->Start);
 }
 #endif

--- a/clientlog/certificates.c
+++ b/clientlog/certificates.c
@@ -232,6 +232,8 @@ void clog_certificates(clog_Arena scratch) {
     if (numCertificates == 0) {
         clog_ArenaAppend(&scratch, "\n(No certificates found in store '%s')", storeLocation);
     }
+    clog_utils_TrimTrailingNewlines(&scratch, NULL);
+    clog_ArenaAppend(&scratch, "\n");
     LOG_DEBUG("\tcertificates.c: End.");
 }
 

--- a/clientlog/clientlog.c
+++ b/clientlog/clientlog.c
@@ -37,9 +37,9 @@ void clientlog(char *mrmachine, void (*mrsend)(char *machine, char *message), vo
     clog_ArenaAppend(&arena, "client %s.windows windows\n", mrmachine);
     clog_ArenaAppend(&arena, "\n");
 
-    // decided to add a new line between each section for better readability, so each section will have two newlines after it
-    // some clientlog tests already have a newline at the end of their output, so we only need to add one more newline after those sections
-    // but most don't, so we need to add two newlines after those sections
+    // Each test must run clog_utils_TrimTrailingNewlines and append a newline after,
+    // to ensure that the output is well-formed and does not have trailing newlines before the next section.
+    // We want to have a single newline between sections, and no trailing newlines at the end of the output.
 
     RUN(clog_date, arena);
     clog_ArenaAppend(&arena, "\n");
@@ -51,7 +51,7 @@ void clientlog(char *mrmachine, void (*mrsend)(char *machine, char *message), vo
     clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_bios, arena);
-    clog_ArenaAppend(&arena, "\n"); 
+    clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_domain, arena);
     clog_ArenaAppend(&arena, "\n");

--- a/clientlog/clientlog.c
+++ b/clientlog/clientlog.c
@@ -43,25 +43,20 @@ void clientlog(char *mrmachine, void (*mrsend)(char *machine, char *message), vo
 
     RUN(clog_date, arena);
     clog_ArenaAppend(&arena, "\n");
-    clog_ArenaAppend(&arena, "\n"); // one line space between sections
 
     RUN(clog_osversion, arena);
-    clog_ArenaAppend(&arena, "\n");
     clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_winuptime, arena);
     clog_ArenaAppend(&arena, "\n");
-    clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_bios, arena);
-    clog_ArenaAppend(&arena, "\n"); // already has a newline at the end of bios info, so only one newline here
+    clog_ArenaAppend(&arena, "\n"); 
 
     RUN(clog_domain, arena);
     clog_ArenaAppend(&arena, "\n");
-    clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_who, 10, arena);
-    clog_ArenaAppend(&arena, "\n");
     clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_cpuinfo, arena);
@@ -69,10 +64,8 @@ void clientlog(char *mrmachine, void (*mrsend)(char *machine, char *message), vo
 
     RUN(clog_diskinfo, arena);
     clog_ArenaAppend(&arena, "\n");
-    clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_winmemory, arena);
-    clog_ArenaAppend(&arena, "\n");
     clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_ipconfig, arena);
@@ -83,10 +76,8 @@ void clientlog(char *mrmachine, void (*mrsend)(char *machine, char *message), vo
 
     RUN(clog_winports, arena);
     clog_ArenaAppend(&arena, "\n");
-    clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_tcp_connections, arena);
-    clog_ArenaAppend(&arena, "\n");
     clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_processes_EndAppendQuery, hProcesses, &arena);
@@ -100,26 +91,20 @@ void clientlog(char *mrmachine, void (*mrsend)(char *machine, char *message), vo
 
     RUN(clog_applications, arena);
     clog_ArenaAppend(&arena, "\n");
-    clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_kbs, arena);
-    clog_ArenaAppend(&arena, "\n");
     clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_certificates, arena);
     clog_ArenaAppend(&arena, "\n");
-    clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_registry, arena);
-    clog_ArenaAppend(&arena, "\n");
     clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_reboots, 5, arena);
     clog_ArenaAppend(&arena, "\n");
-    clog_ArenaAppend(&arena, "\n");
 
     RUN(clog_clientversion, arena);
-    clog_ArenaAppend(&arena, "\n");
     clog_ArenaAppend(&arena, "\n");
 
 

--- a/clientlog/clientlog.h
+++ b/clientlog/clientlog.h
@@ -24,6 +24,7 @@ enum clog_utils_PrettyTimestampFlags {
 };
 LPSTR clog_utils_PrettySystemtime(SYSTEMTIME *t, UINT8 flags, LPSTR out, size_t outSize);
 DWORD clog_utils_RunCmdSynchronously(CHAR *cmdline, clog_Arena scratch);
+void clog_utils_TrimTrailingNewlines(clog_Arena *scratch, BYTE *from);
 
 /* applications */
 void clog_applications(clog_Arena scratch);

--- a/clientlog/clientversion.c
+++ b/clientlog/clientversion.c
@@ -10,10 +10,12 @@
 void clog_clientversion(clog_Arena scratch) {
     clog_ArenaAppend(&scratch, "[clientversion]");
     if (PACKAGE[0] == '\0' || VERSION[0] == '\0') {
-        clog_ArenaAppend(&scratch, "\nMrBig version unknown");
+        clog_ArenaAppend(&scratch, "\nMrBig version unknown\n");
     } else {
-        clog_ArenaAppend(&scratch, "\n" PACKAGE " version " VERSION);
+        clog_ArenaAppend(&scratch, "\n" PACKAGE " version " VERSION "\n");
     }
+    clog_utils_TrimTrailingNewlines(&scratch, NULL);
+    clog_ArenaAppend(&scratch, "\n");
 }
 
 #ifdef STANDALONE

--- a/clientlog/clock.c
+++ b/clientlog/clock.c
@@ -102,6 +102,8 @@ void clog_clock(clog_Arena scratch) {
     } else {
         clog_ArenaAppend(&scratch, "W32Time service is not running.\n");
     }
+    clog_utils_TrimTrailingNewlines(&scratch, NULL);
+    clog_ArenaAppend(&scratch, "\n");
 }
 
 #ifdef STANDALONE

--- a/clientlog/cpuinfo.c
+++ b/clientlog/cpuinfo.c
@@ -85,7 +85,9 @@ void clog_cpuinfo(clog_Arena scratch) {
     } else {
         clog_ArenaAppend(&scratch, "    SMT per core: N/A\n");
     }
-    clog_ArenaAppend(&scratch, "       SMT total: %d\n", total);
+    clog_ArenaAppend(&scratch, "       SMT total: %d\n\n", total);
+    clog_utils_TrimTrailingNewlines(&scratch, NULL);
+    clog_ArenaAppend(&scratch, "\n");
 }
 
 #ifdef STANDALONE

--- a/clientlog/date.c
+++ b/clientlog/date.c
@@ -1,3 +1,4 @@
+#include "arena.h"
 #include "clientlog.h"
 
 #define TIME_BUF_SIZE 12
@@ -15,6 +16,8 @@ void clog_date(clog_Arena scratch) {
 
     clog_ArenaAppend(&scratch, "[date]\n");
     clog_ArenaAppend(&scratch, "%s %s", s_date, s_time);
+    clog_utils_TrimTrailingNewlines(&scratch, NULL);
+    clog_ArenaAppend(&scratch, "\n");
 }
 
 #ifdef STANDALONE

--- a/clientlog/diskinfo.c
+++ b/clientlog/diskinfo.c
@@ -295,6 +295,8 @@ void clog_diskinfo(clog_Arena scratch) {
         LOG_DEBUG("\tdiskinfo.c: End of physical drive '%lu'.", i);
     }
 #undef ArenaIndentAppend
+    clog_utils_TrimTrailingNewlines(&scratch, NULL);
+    clog_ArenaAppend(&scratch, "\n");
 }
 
 #ifdef STANDALONE

--- a/clientlog/domain.c
+++ b/clientlog/domain.c
@@ -60,6 +60,8 @@ void clog_domain(clog_Arena scratch) {
 
     clog_ArenaAppend(&scratch, "\n%13s:\t%s", "UPNDomain", upnDomain);
     clog_ArenaAppend(&scratch, "\n%13s:\t%s", "FQDN", fqdn);
+    clog_utils_TrimTrailingNewlines(&scratch, NULL);
+    clog_ArenaAppend(&scratch, "\n");
 }
 
 #ifdef STANDALONE

--- a/clientlog/eventlog.c
+++ b/clientlog/eventlog.c
@@ -142,7 +142,7 @@ void clog_eventlog(DWORD maxNumEvents, clog_Arena scratch) {
     for (DWORD channelIx = 0; channelIx < NUM_CHANNELS; channelIx++) {
         CHAR channelName[32];
         wcstombs(channelName, CHANNELS[channelIx], 32);
-        clog_ArenaAppend(&scratch, "\n[eventlog_%s]", CharLowerA(channelName));
+        clog_ArenaAppend(&scratch, "[eventlog_%s]", CharLowerA(channelName));
 
         EVT_HANDLE hLog = EvtQuery(NULL, CHANNELS[channelIx], L"Event/System[Level<4 and TimeCreated[timediff(@SystemTime) <= " STR(MAX_EVENT_AGE_MS) "]]", EvtQueryChannelPath | EvtQueryReverseDirection);
         clog_Defer(&scratch, hLog, RETURN_INT, &EvtClose);
@@ -163,8 +163,11 @@ void clog_eventlog(DWORD maxNumEvents, clog_Arena scratch) {
             clog_ArenaAppend(&scratch, "\n(No warnings or errors found within the last %lfh.)", MAX_EVENT_AGE_MS / 3600000.0);
         }
         clog_ArenaAppend(&scratch, "\n");
+        clog_ArenaAppend(&scratch, "\n");
         clog_PopDefer(&scratch);
     }
+    clog_utils_TrimTrailingNewlines(&scratch, NULL);
+    clog_ArenaAppend(&scratch, "\n");
 }
 
 #ifdef STANDALONE

--- a/clientlog/ipconfig.c
+++ b/clientlog/ipconfig.c
@@ -1,6 +1,7 @@
 #include "clientlog.h"
 
 void clog_ipconfig(clog_Arena scratch) {
-    clog_ArenaAppend(&scratch, "[ipconfig]\n");
+    clog_ArenaAppend(&scratch, "[ipconfig]");
     clog_utils_RunCmdSynchronously("C:\\Windows\\System32\\ipconfig.exe /all", scratch);
+    clog_ArenaAppend(&scratch, "\n");
 }

--- a/clientlog/kbs.c
+++ b/clientlog/kbs.c
@@ -399,6 +399,8 @@ Cleanup:
         LOG_DEBUG("\tkbs.c: No installed KBs found.");
         clog_ArenaAppend(&scratch, "(No KBs found)");
     }
+    clog_utils_TrimTrailingNewlines(&scratch, NULL);
+    clog_ArenaAppend(&scratch, "\n");
 
 }
 

--- a/clientlog/osversion.c
+++ b/clientlog/osversion.c
@@ -176,6 +176,8 @@ void clog_osversion(clog_Arena scratch) {
         clog_ArenaAppend(&scratch, "\nInstalled suites:\n%s", installedSuites);
     }
     */
+    clog_utils_TrimTrailingNewlines(&scratch, NULL);
+    clog_ArenaAppend(&scratch, "\n");
 }
 
 #ifdef STANDALONE

--- a/clientlog/processes.c
+++ b/clientlog/processes.c
@@ -382,6 +382,8 @@ void clog_processes_EndAppendQuery(processes_Handle h, clog_Arena *a)
         processes_SortBy(&endedQuery, &processes__CompareMemory, a);
         processes_AppendTable(endedQuery, NUM_TOPPROCESSES, a);
     }
+    clog_utils_TrimTrailingNewlines(a, NULL);
+    clog_ArenaAppend(a, "\n");
 }
 
 void _processes(clog_Arena scratch)

--- a/clientlog/reboots.c
+++ b/clientlog/reboots.c
@@ -161,6 +161,8 @@ void clog_reboots(DWORD maxNumReboots, clog_Arena scratch) {
     for (DWORD i = 0; i < numRebootsFound; i++) {
         clog_ArenaAppend(&scratch, "\n%s", reboots_PrettyEvent(&rebootevents[i], rebootOutputBuffer));
     }
+    clog_utils_TrimTrailingNewlines(&scratch, NULL);
+    clog_ArenaAppend(&scratch, "\n");
 }
 
 #ifdef STANDALONE

--- a/clientlog/registry.c
+++ b/clientlog/registry.c
@@ -613,6 +613,8 @@ void clog_registry(clog_Arena scratch) {
             numSucceeded++;
         }
     }
+    clog_utils_TrimTrailingNewlines(&scratch, NULL);
+    clog_ArenaAppend(&scratch, "\n");
 
     LOG_DEBUG("\tregistry.c: Completed registry read pass (attempted=%llu, "
               "succeeded=%llu, skipped=%llu).",

--- a/clientlog/runningservices.c
+++ b/clientlog/runningservices.c
@@ -125,6 +125,8 @@ void clog_runningservices(clog_Arena scratch) {
             clog_PopDefer(&scratch);
         }
     }
+    clog_utils_TrimTrailingNewlines(&scratch, NULL);
+    clog_ArenaAppend(&scratch, "\n");
 }
 
 #ifdef STANDALONE

--- a/clientlog/tcpconnections.c
+++ b/clientlog/tcpconnections.c
@@ -680,6 +680,8 @@ void clog_tcp_connections(clog_Arena scratch) {
                          targetPort);
     }
 
+    clog_utils_TrimTrailingNewlines(&scratch, NULL);
+    clog_ArenaAppend(&scratch, "\n");
 
     free(established);
     free(tcp4);

--- a/clientlog/utils.c
+++ b/clientlog/utils.c
@@ -61,6 +61,29 @@ LPSTR clog_utils_PrettySystemtime(SYSTEMTIME *t, UINT8 flags, LPSTR out, size_t 
 
 #define PROCESS_TIMOUT_LIMIT_MS 1000
 #define BUFREAD 513
+void clog_utils_TrimTrailingNewlines(clog_Arena *scratch, BYTE *from) {
+    clog_ArenaState *state = (clog_ArenaState *)scratch->State;
+    if (!state || !state->Start || !state->End || !state->CurrentStart) {
+        return;
+    }
+
+    if (!from || from < state->Start) {
+        from = state->Start;
+    }
+    if (from > state->CurrentStart) {
+        from = state->CurrentStart;
+    }
+
+    while (state->CurrentStart > from &&
+           (state->CurrentStart[-1] == '\n' || state->CurrentStart[-1] == '\r')) {
+        state->CurrentStart--;
+    }
+
+    if (state->CurrentStart < state->End) {
+        *state->CurrentStart = '\0';
+    }
+}
+
 /** Run a shell command. Callers should call clog_PopDeferAll(&scratch) after this function has been used.
  * @param cmdline the command to run, including flags
  * @param scratch a clientlog arena to which the output will be appended
@@ -70,6 +93,11 @@ DWORD clog_utils_RunCmdSynchronously(CHAR *cmdline, clog_Arena scratch) {
     HANDLE hPipeOutputRead = NULL;
     HANDLE hPipeOutputWrite = NULL;
     DWORD status = 0;
+    clog_ArenaState *scratchState = (clog_ArenaState *)scratch.State;
+    if (!scratchState || !scratchState->Start || !scratchState->End || !scratchState->CurrentStart) {
+        return ERROR_INVALID_PARAMETER;
+    }
+    BYTE *outputStart = scratchState->CurrentStart;
 
     SECURITY_ATTRIBUTES securityAttributes;
     // Set the bInheritHandle flag so pipe handles are inherited.
@@ -129,7 +157,7 @@ DWORD clog_utils_RunCmdSynchronously(CHAR *cmdline, clog_Arena scratch) {
     // Poll: drain the pipe continuously while waiting for the process to exit.
     // A blocking WaitForSingleObject before ReadFile deadlocks when the child's
     // output fills the pipe buffer (child blocks on WriteFile, parent blocks on Wait).
-    DWORD readBufLen = 0, written = 0;
+    DWORD readBufLen = 0;
     CHAR readBuf[BUFREAD];
     DWORD startTick = GetTickCount();
     BOOL processExited = FALSE;
@@ -142,7 +170,6 @@ DWORD clog_utils_RunCmdSynchronously(CHAR *cmdline, clog_Arena scratch) {
             if (!ReadFile(hPipeOutputRead, readBuf, toRead, &readBufLen, NULL) || readBufLen == 0) break;
             readBuf[readBufLen] = '\0';
             clog_ArenaAppend(&scratch, "%s", readBuf);
-            written += readBufLen;
         }
 
         status = WaitForSingleObject(procInfo.hProcess, 0);
@@ -176,13 +203,16 @@ DWORD clog_utils_RunCmdSynchronously(CHAR *cmdline, clog_Arena scratch) {
         if (!ReadFile(hPipeOutputRead, readBuf, toRead, &readBufLen, NULL) || readBufLen == 0) break;
         readBuf[readBufLen] = '\0';
         clog_ArenaAppend(&scratch, "%s", readBuf);
-        written += readBufLen;
     }
 
     CloseHandle(procInfo.hProcess);
     CloseHandle(procInfo.hThread);
     CloseHandle(hPipeOutputRead);
-    if (written <= 0) {
+
+    // Most commands print one trailing CRLF; trim it to avoid blank lines in reports.
+    clog_utils_TrimTrailingNewlines(&scratch, outputStart);
+
+    if (scratchState->CurrentStart <= outputStart) {
         clog_ArenaAppend(&scratch, "(No output)");
     }
 

--- a/clientlog/who.c
+++ b/clientlog/who.c
@@ -134,6 +134,8 @@ void clog_who(DWORD maxNumSessions, clog_Arena scratch) {
     if (numSessions >= maxNumSessions) {
         clog_ArenaAppend(&scratch, "\n(...with up to %lu more sessions truncated for brevity.)", numUnfilteredSessions - numSessions);
     }
+    clog_utils_TrimTrailingNewlines(&scratch, NULL);
+    clog_ArenaAppend(&scratch, "\n");
 }
 
 #ifdef STANDALONE

--- a/clientlog/winmemory.c
+++ b/clientlog/winmemory.c
@@ -81,6 +81,8 @@ void clog_winmemory(clog_Arena scratch) {
                      clog_utils_PrettyBytes(usedVirtualBytes, 2, usedPhys),
                      clog_utils_PrettyBytes(freeVirtualBytes, 2, freePhys),
                      percentVirtualUsed);
+    clog_utils_TrimTrailingNewlines(&scratch, NULL);
+    clog_ArenaAppend(&scratch, "\n");
 }
 
 #ifdef STANDALONE

--- a/clientlog/winports.c
+++ b/clientlog/winports.c
@@ -273,7 +273,8 @@ void clog_winports(clog_Arena scratch) {
     else if (errored > 0)
         clog_ArenaAppend(&scratch, "\n(Unable to get some of the networking statistics)");
 
-    clog_ArenaAppend(&scratch, "\n\n[winports]");
+    clog_ArenaAppend(&scratch, "\n");
+    clog_ArenaAppend(&scratch, "\n[winports]");
     clog_ArenaAppend(&scratch, "\n%-7s\t%-39s\t%-39s\t%-15s\t%7s", "Proto", "Local Address", "Foreign Address", "State", "PID");
     errored = 0;
     for (int i = 0; i < lengthof(portGroups); i++) {
@@ -287,6 +288,8 @@ void clog_winports(clog_Arena scratch) {
         clog_ArenaAppend(&scratch, "\n(Unable to get networking statistics)");
     else if (errored > 0)
         clog_ArenaAppend(&scratch, "\n(Unable to get some of the networking statistics)");
+    clog_utils_TrimTrailingNewlines(&scratch, NULL);
+    clog_ArenaAppend(&scratch, "\n");
 }
 
 #ifdef STANDALONE

--- a/clientlog/winroute.c
+++ b/clientlog/winroute.c
@@ -3,6 +3,8 @@
 void clog_winroute(clog_Arena scratch) {
     clog_ArenaAppend(&scratch, "[winroute]\n");
     clog_utils_RunCmdSynchronously("C:\\Windows\\System32\\route print", scratch);
+    clog_utils_TrimTrailingNewlines(&scratch, NULL);
+    clog_ArenaAppend(&scratch, "\n");
 }
 
 #ifdef STANDALONE

--- a/clientlog/winuptime.c
+++ b/clientlog/winuptime.c
@@ -51,6 +51,8 @@ void clog_winuptime(clog_Arena scratch) {
                    uptime_days, uptime_hours, uptime_minutes,
                    boottime.wYear, boottime.wMonth, boottime.wDay,
                    boottime.wHour, boottime.wMinute, boottime.wSecond);
+    clog_utils_TrimTrailingNewlines(&scratch, NULL);
+    clog_ArenaAppend(&scratch, "\n");
 }
 
 #ifdef STANDALONE


### PR DESCRIPTION
Normalize spacing after clientlog sections. 

Example
```
[clientlog-test]\n
this is a test\n
hello\n
\n
```
trim new trailing new lines
```
[clientlog-test]\n
this is a test\n
hello
```

add new line
```
[clientlog-test]\n
this is a test\n
hello\n
```

then in clientlog.c, add the newline to create a space between sections.